### PR TITLE
Feature/ritm1290649

### DIFF
--- a/_includes/policy-resource-button.html
+++ b/_includes/policy-resource-button.html
@@ -39,7 +39,7 @@
             <li><a aria-label="Filter by Category: Customer Experience" role="checkbox" aria-checked="false" href="javascript:void(0)" data-filter=".cx">Customer Experience</a></li>
             <li><a aria-label="Filter by Category: IT Modernization" role="checkbox" aria-checked="false" href="javascript:void(0)" data-filter=".it-modernization">IT Modernization</a></li>
             <li><a aria-label="Filter by Category: Best Practices" role="checkbox" aria-checked="false" href="javascript:void(0)" data-filter=".best-practices">Best Practices</a></li>
-            <li><a aria-label="Filter by Category: Energy Act EO" role="checkbox" aria-checked="false" href="javascript:void(0)" data-filter=".eao">Energy Act EO</a></li>
+            <!-- <li><a aria-label="Filter by Category: Energy Act EO" role="checkbox" aria-checked="false" href="javascript:void(0)" data-filter=".eao">Energy Act EO</a></li> -->
             <li><a aria-label="Filter by Category: Artificial Intelligence" role="checkbox" aria-checked="false" href="javascript:void(0)" data-filter=".artificial-intelligence">Artificial Intelligence</a></li>
         </ul>
 

--- a/_policies/DCOI.md
+++ b/_policies/DCOI.md
@@ -9,10 +9,9 @@ filters: fed-policy cloud data-center-consolidation active data
 related-policies-url: /policies-and-priorities/#subject=*&role=.data-center-consolidation&status=*
 related-filters: 'data-center-consolidation'
 date: August 1, 2016
-published: False
 ---
 ## Policy Overview ##
-The [Data Center Optimization Initiative (DCOI)](https://datacenters.cio.gov/) was established in [OMB Memorandum M-19-19](https://www.whitehouse.gov/wp-content/uploads/2019/06/M-19-19-Data-Centers.pdf) in August 2016. It supercedes the Federal Data Center Consolidation Initiative (FDCCI) and fulfills the data center requirements of the [Federal Information Technology Acquisition Reform Act (FITARA)]({{ site.baseurl }}/policies-and-priorities/FITARA/). M-19-19 rescinds and replaces M-16-19 Data Center Optimization Initiative.
+The Data Center Optimization Initiative (DCOI) was established in [OMB Memorandum M-19-19](https://www.whitehouse.gov/wp-content/uploads/2019/06/M-19-19-Data-Centers.pdf) in August 2016. It supercedes the Federal Data Center Consolidation Initiative (FDCCI) and fulfills the data center requirements of the [Federal Information Technology Acquisition Reform Act (FITARA)]({{ site.baseurl }}/policies-and-priorities/FITARA/). M-19-19 rescinds and replaces M-16-19 Data Center Optimization Initiative.
 
 The DCOI requires agencies to develop and report on data center strategies to consolidate inefficient infrastructure, optimize existing facilities, improve security posture, achieve cost savings, and transition to more efficient infrastructure, such as cloud services and inter-agency shared services
 &nbsp;

--- a/_policies/DCOI.md
+++ b/_policies/DCOI.md
@@ -9,6 +9,7 @@ filters: fed-policy cloud data-center-consolidation active data
 related-policies-url: /policies-and-priorities/#subject=*&role=.data-center-consolidation&status=*
 related-filters: 'data-center-consolidation'
 date: August 1, 2016
+published: False
 ---
 ## Policy Overview ##
 The [Data Center Optimization Initiative (DCOI)](https://datacenters.cio.gov/) was established in [OMB Memorandum M-19-19](https://www.whitehouse.gov/wp-content/uploads/2019/06/M-19-19-Data-Centers.pdf) in August 2016. It supercedes the Federal Data Center Consolidation Initiative (FDCCI) and fulfills the data center requirements of the [Federal Information Technology Acquisition Reform Act (FITARA)]({{ site.baseurl }}/policies-and-priorities/FITARA/). M-19-19 rescinds and replaces M-16-19 Data Center Optimization Initiative.

--- a/_resources/fcio.md
+++ b/_resources/fcio.md
@@ -4,5 +4,5 @@ date: Jan 1, 9999
 description: OMB's Office of E-Government & Information Technology develops and provides direction in the use of Internet-based technologies
 external_url: whitehouse.gov/omb/management/egov/
 filters: website council-operations current
-
+published: False
 ---


### PR DESCRIPTION
Approved

[Preview](https://cg-f7a6dbc1-b791-40b1-9eeb-e725679c82c9.sites.pages.cloud.gov/preview/gsa/cio.gov-redo/feature/RITM1290649/policies-and-priorities/)

We have several links/hyperlinks that we would like removed from the policy and priority catalog on CIO.gov

Remove Links
Data Category
•	Data Center Optimization initiative: https://www.cio.gov/policies-and-priorities/DCOI/
o	Remove Data Center Optimization hyperlink - https://datacenters.cio.gov/ (Broken Link)

Council Operation
•	Remove hyperlink - Office of the Federal Chief Information Officer E-Gov https://www.whitehouse.gov/omb/management/egov/ 

Energy Act EO - https://www.cio.gov/policies-and-priorities/#subject=*&role=.eao&status=*
•	Nothing on this tile please remove