### PR TITLE
Feature/ritm1294514

### DIFF
--- a/_data/members.json
+++ b/_data/members.json
@@ -592,8 +592,8 @@
           "agencyName": "Small Business Administration",
           "agencyCode": "028",
           "cio": {
-            "firstName": "Stephen",
-            "lastName": "Kucharski",
+            "firstName": "Marcus",
+            "lastName": "Alzona",
             "email": "",
             "phone": "",
             "dateAppointed": "",
@@ -611,7 +611,7 @@
             "banner_subtitle": "Team and Leadership",
             "banner_title":" About Our Council",
             "leadership": false,
-            "position": "Acting Chief Information Officer",
+            "position": "Chief Information Officer",
             "bio-image": "/sba-seal-placeholder.png",
             "description": ""
           }


### PR DESCRIPTION
Approved

[Preview](https://cg-f7a6dbc1-b791-40b1-9eeb-e725679c82c9.sites.pages.cloud.gov/preview/gsa/cio.gov-redo/feature/RITM1294514/about/members-and-leadership/)

On the Members and Leadership page, please remove SBA CIO Stephen Kucharski and replace him with Marcus Alzona. His title should be updated to 'Chief Information Officer.